### PR TITLE
fix: prevent generated dependency cache PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 # Changelog
+
 [Compare changes](https://github.com/stacksjs/buddy-bot/compare/v0.9.21...v0.9.22)
 
-### ⚡ Performance Improvements
+## ⚡ Performance Improvements
 
 - **build**: drop external sourcemaps from published package ([3fb2223](https://github.com/stacksjs/buddy-bot/commit/3fb2223)) _(by Chris <chrisbreuer93@gmail.com>)_
 
-### 🧹 Chores
+## 🧹 Chores
 
 - release v0.9.22 ([2c99ecc](https://github.com/stacksjs/buddy-bot/commit/2c99ecc)) _(by Chris <chrisbreuer93@gmail.com>)_
 
-### Contributors
+## Contributors
 
 - _Chris <chrisbreuer93@gmail.com>_
 

--- a/docs/features/github-actions.md
+++ b/docs/features/github-actions.md
@@ -16,7 +16,7 @@ GitHub Actions integration provides:
 
 Buddy automatically detects GitHub Actions in:
 
-```
+```text
 .github/
 └── workflows/
     ├── ci.yml

--- a/docs/sponsors.md
+++ b/docs/sponsors.md
@@ -128,4 +128,4 @@ You can also try to convince your employer to sponsor Stacks as a business. This
 
 #### Thanks to Vue.js for the inspiration of this sponsorship page
 
-*You can find their sponsorship page [here](https://vuejs.org/sponsor/).*
+*You can find the [Vue.js sponsorship page](https://vuejs.org/sponsor/).*

--- a/src/git/github-provider.ts
+++ b/src/git/github-provider.ts
@@ -3,6 +3,7 @@ import type { FileChange, GitProvider, Issue, IssueOptions, PullRequest, PullReq
 import { Buffer } from 'node:buffer'
 import { spawn } from 'node:child_process'
 import process from 'node:process'
+import { assertUpdateTargetsExist, FileChangeValidationError, normalizeRepositoryPath } from '../utils/file-changes'
 import { detectRequiredPackageManagers, getAllLockFilePaths, regenerateLockFile } from '../utils/lock-file'
 
 // Match GitHub token formats (ghp_*, gho_*, ghs_*, ghu_*, ghr_*, github_pat_*)
@@ -141,7 +142,7 @@ export class GitHubProvider implements GitProvider {
       // Lockfile regeneration failures must NOT fall through to the API path —
       // the API path can't regenerate lockfiles either, so it would just produce
       // a PR with an updated manifest and stale lockfile. Bubble the error up.
-      if (gitError instanceof LockfileRegenerationError)
+      if (gitError instanceof LockfileRegenerationError || gitError instanceof FileChangeValidationError)
         throw gitError
 
       console.warn(`⚠️ Git CLI commit failed, falling back to GitHub API: ${gitError}`)
@@ -240,9 +241,19 @@ export class GitHubProvider implements GitProvider {
       await this.runCommand('git', ['clean', '-fd'])
       console.log(`✅ Reset ${branchName} to origin/${baseBranch}`)
 
+      await assertUpdateTargetsExist(files, async (cleanPath) => {
+        try {
+          await this.runCommand('git', ['cat-file', '-e', `origin/${baseBranch}:${cleanPath}`])
+          return true
+        }
+        catch {
+          return false
+        }
+      })
+
       // Apply file changes
       for (const file of files) {
-        const cleanPath = file.path.replace(/^\.\//, '').replace(/^\/+/, '')
+        const cleanPath = normalizeRepositoryPath(file.path)
 
         // Safety check: prevent writing to sensitive files during tests
         if (process.env.NODE_ENV === 'test' || process.env.BUN_ENV === 'test') {
@@ -395,11 +406,23 @@ export class GitHubProvider implements GitProvider {
       const baseCommit = await this.apiRequest(`GET /repos/${this.owner}/${this.repo}/git/commits/${baseSha}`)
       const baseTreeSha = baseCommit.tree.sha
 
+      await assertUpdateTargetsExist(files, async (cleanPath) => {
+        const encodedPath = cleanPath.split('/').map(segment => encodeURIComponent(segment)).join('/')
+        try {
+          await this.apiRequest(`GET /repos/${this.owner}/${this.repo}/contents/${encodedPath}?ref=${encodeURIComponent(baseBranch)}`)
+          return true
+        }
+        catch (error: any) {
+          if (error.message?.includes('404'))
+            return false
+          throw error
+        }
+      })
+
       // Create new tree with file changes
       const tree = []
       for (const file of files) {
-        // Ensure path doesn't start with ./ or have leading slashes (GitHub API requires clean relative paths)
-        const cleanPath = file.path.replace(/^\.\//, '').replace(/^\/+/, '')
+        const cleanPath = normalizeRepositoryPath(file.path)
 
         if (file.type === 'delete') {
           tree.push({

--- a/src/pr/pr-generator.ts
+++ b/src/pr/pr-generator.ts
@@ -383,8 +383,10 @@ export class PullRequestGenerator {
         }
 
         // Generate version change with diff link (Renovate style)
-        const diffUrl = `https://renovatebot.com/diffs/npm/${encodeURIComponent(cleanPackageName)}/${update.currentVersion}/${update.newVersion}`
-        const change = `[\`${update.currentVersion}\` -> \`${update.newVersion}\`](${diffUrl})`
+        const diffUrl = `https://renovatebot.com/diffs/npm/${encodeURIComponent(cleanPackageName)}/${encodeURIComponent(update.currentVersion)}/${encodeURIComponent(update.newVersion)}`
+        const currentVersion = this.escapeMarkdownTableValue(update.currentVersion)
+        const newVersion = this.escapeMarkdownTableValue(update.newVersion)
+        const change = `[\`${currentVersion}\` -> \`${newVersion}\`](${diffUrl})`
 
         // Generate confidence badges with clean package name
         const badges = this.releaseNotesFetcher.generatePackageBadges(
@@ -975,6 +977,13 @@ export class PullRequestGenerator {
     const newConstraint = `^${cleanNew}`
 
     return `${currentConstraint} -> ${newConstraint}`
+  }
+
+  /**
+   * Escape delimiters that would otherwise split a GitHub Markdown table row.
+   */
+  private escapeMarkdownTableValue(value: string): string {
+    return value.replaceAll('|', '\\|').replaceAll(/\r?\n/g, ' ')
   }
 
   /**

--- a/src/registry/registry-client.ts
+++ b/src/registry/registry-client.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { PackageRegistryError } from '../types'
 import { getUpdateType } from '../utils/helpers'
+import { shouldSkipPackageDirectory } from '../utils/package-paths'
 
 export interface BunOutdatedResult {
   name: string
@@ -1342,26 +1343,10 @@ export class RegistryClient {
   }
 
   /**
-   * Check if a directory should be skipped during scanning
+   * Check if a directory is safe to descend into during package discovery.
    */
   private shouldSkipDirectory(dirName: string): boolean {
-    const skipDirs = [
-      'node_modules',
-      '.git',
-      '.next',
-      '.nuxt',
-      'dist',
-      'build',
-      'coverage',
-      '.nyc_output',
-      'tmp',
-      'temp',
-      '.cache',
-      '.vscode',
-      '.idea',
-    ]
-
-    return skipDirs.includes(dirName) || dirName.startsWith('.')
+    return shouldSkipPackageDirectory(dirName)
   }
 
   /**

--- a/src/scanner/package-scanner.ts
+++ b/src/scanner/package-scanner.ts
@@ -10,6 +10,7 @@ import { BuddyError } from '../types'
 import { isDependencyFile, parseDependencyFile as parseDepFile } from '../utils/dependency-file-parser'
 import { isDockerfile, parseDockerfile as parseDockerfileUtil } from '../utils/dockerfile-parser'
 import { isGitHubActionsFile, parseGitHubActionsFile } from '../utils/github-actions-parser'
+import { shouldSkipPackageDirectory } from '../utils/package-paths'
 import { parsePantryLockFile } from '../utils/pantry-parser'
 import { parseZigManifest } from '../utils/zig-parser'
 
@@ -537,7 +538,7 @@ export class PackageScanner {
 
           if (stats.isDirectory()) {
             // Skip node_modules and other common ignored directories
-            if (!this.shouldSkipDirectory(entry)) {
+            if (!shouldSkipPackageDirectory(entry)) {
               const subFiles = await this.findFiles(fileName, fullPath)
               files.push(...subFiles)
             }
@@ -597,7 +598,7 @@ export class PackageScanner {
           // Normalize path separators to forward slashes for consistency
           files.push(relativePath.split(sep).join('/'))
         }
-        else if (stats.isDirectory() && !this.shouldSkipDirectory(entry)) {
+        else if (stats.isDirectory() && !shouldSkipPackageDirectory(entry)) {
           // Recursively search subdirectories
           const subFiles = await this.findFilesByPatternInDir(pattern, fullPath)
           files.push(...subFiles)
@@ -631,7 +632,7 @@ export class PackageScanner {
           // Normalize path separators to forward slashes for consistency
           files.push(relativePath.split(sep).join('/'))
         }
-        else if (stats.isDirectory() && !this.shouldSkipDirectory(entry)) {
+        else if (stats.isDirectory() && !shouldSkipPackageDirectory(entry)) {
           const subFiles = await this.findFilesByPatternInDir(pattern, fullPath)
           files.push(...subFiles)
         }
@@ -668,29 +669,6 @@ export class PackageScanner {
     }
 
     return false
-  }
-
-  /**
-   * Check if a directory should be skipped during scanning
-   */
-  private shouldSkipDirectory(dirName: string): boolean {
-    const skipDirs = [
-      'node_modules',
-      '.git',
-      '.next',
-      '.nuxt',
-      'dist',
-      'build',
-      'coverage',
-      '.nyc_output',
-      'tmp',
-      'temp',
-      '.cache',
-      '.vscode',
-      '.idea',
-    ]
-
-    return skipDirs.includes(dirName) || dirName.startsWith('.')
   }
 
   /**

--- a/src/services/release-notes-fetcher.ts
+++ b/src/services/release-notes-fetcher.ts
@@ -139,7 +139,7 @@ export class ReleaseNotesFetcher {
         },
         releaseNotes: [],
         changelog: [],
-        compareUrl: `https://github.com/${repoInfo.owner}/${repoInfo.repo}/compare/v${currentVersion}...v${newVersion}`,
+        compareUrl: this.generateCompareUrl(repoInfo.owner, repoInfo.repo, currentVersion, newVersion),
       }
     }
 
@@ -435,28 +435,67 @@ export class ReleaseNotesFetcher {
   /**
    * Generate compare URL between versions
    */
-  private generateCompareUrl(owner: string, repo: string, fromVersion: string, toVersion: string): string {
-    const cleanFrom = fromVersion.startsWith('v') ? fromVersion : `v${fromVersion}`
-    const cleanTo = toVersion.startsWith('v') ? toVersion : `v${toVersion}`
-    return `https://github.com/${owner}/${repo}/compare/${cleanFrom}...${cleanTo}`
+  private generateCompareUrl(owner: string, repo: string, fromVersion: string, toVersion: string): string | undefined {
+    const cleanFrom = this.getComparableVersion(fromVersion)
+    const cleanTo = this.getComparableVersion(toVersion)
+    if (!cleanFrom || !cleanTo)
+      return undefined
+
+    return `https://github.com/${owner}/${repo}/compare/${encodeURIComponent(`v${cleanFrom}`)}...${encodeURIComponent(`v${cleanTo}`)}`
   }
 
   /**
    * Check if version is between current and new version
    */
   private isVersionBetween(version: string, current: string, target: string): boolean {
-    const cleanVersion = version.replace(/^v/, '')
-    const cleanCurrent = current.replace(/^v/, '')
-    const cleanTarget = target.replace(/^v/, '')
+    const cleanVersion = this.getComparableVersion(version)
+    const cleanCurrent = this.getComparableVersion(current)
+    const cleanTarget = this.getComparableVersion(target)
+    if (!cleanVersion || !cleanCurrent || !cleanTarget)
+      return false
 
-    // Proper semver compare — lexicographic ordering gets `1.10.0 > 1.9.0` wrong.
-    // Fall back to string equality if either side isn't valid semver.
     try {
-      return cleanVersion === cleanTarget || semver.order(cleanVersion, cleanCurrent) > 0
+      return semver.order(cleanVersion, cleanCurrent) > 0
+        && semver.order(cleanVersion, cleanTarget) <= 0
     }
     catch {
-      return cleanVersion === cleanTarget || cleanVersion > cleanCurrent
+      return cleanVersion > cleanCurrent && cleanVersion <= cleanTarget
     }
+  }
+
+  /**
+   * Derive a concrete lower-bound version for compare links and ordering.
+   * For OR ranges, use the highest alternative's lower bound.
+   */
+  private getComparableVersion(version: string): string | null {
+    const candidates = version.split('||').flatMap((alternative) => {
+      const trimmed = alternative.trim()
+      if (trimmed.startsWith('<'))
+        return []
+
+      const match = trimmed.match(/^(?:[~^]|>=?|=)?\s*v?(\d+(?:\.\d+){0,2}(?:-[0-9A-Z.-]+)?)/i)
+      if (!match)
+        return []
+
+      const [core, prerelease] = match[1].split('-', 2)
+      const parts = core.split('.')
+      while (parts.length < 3)
+        parts.push('0')
+
+      return [`${parts.join('.')}${prerelease ? `-${prerelease}` : ''}`]
+    })
+
+    if (candidates.length === 0)
+      return null
+
+    return candidates.reduce((highest, candidate) => {
+      try {
+        return semver.order(candidate, highest) > 0 ? candidate : highest
+      }
+      catch {
+        return candidate > highest ? candidate : highest
+      }
+    })
   }
 
   /**

--- a/src/utils/file-changes.ts
+++ b/src/utils/file-changes.ts
@@ -1,0 +1,41 @@
+import type { FileChange } from '../types'
+import { posix } from 'node:path'
+
+export class FileChangeValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FileChangeValidationError'
+  }
+}
+
+/**
+ * Convert a user or scanner supplied path into a safe repository-relative path.
+ */
+export function normalizeRepositoryPath(filePath: string): string {
+  const normalized = posix.normalize(filePath.replaceAll('\\', '/').replace(/^\.\/+/, ''))
+
+  if (!normalized || normalized === '.' || normalized === '..' || normalized.startsWith('../') || posix.isAbsolute(normalized)) {
+    throw new FileChangeValidationError(`Refusing unsafe repository path: ${JSON.stringify(filePath)}`)
+  }
+
+  return normalized
+}
+
+/**
+ * An update must modify a file that already exists on the base branch. Treating
+ * a missing update target as a create is how generated cache paths can leak
+ * into dependency PRs.
+ */
+export async function assertUpdateTargetsExist(
+  files: FileChange[],
+  targetExists: (path: string) => boolean | Promise<boolean>,
+): Promise<void> {
+  for (const file of files) {
+    const cleanPath = normalizeRepositoryPath(file.path)
+    if (file.type === 'update' && !(await targetExists(cleanPath))) {
+      throw new FileChangeValidationError(
+        `Refusing to create missing update target: ${cleanPath}. Use change type "create" for intentional new files.`,
+      )
+    }
+  }
+}

--- a/src/utils/package-paths.ts
+++ b/src/utils/package-paths.ts
@@ -1,0 +1,32 @@
+const GENERATED_DEPENDENCY_DIRECTORIES = new Set([
+  'bower_components',
+  'node_modules',
+  'pantry',
+  'ts-pantry',
+  'vendor',
+])
+
+const GENERATED_OUTPUT_DIRECTORIES = new Set([
+  '.cache',
+  '.idea',
+  '.next',
+  '.nuxt',
+  '.nyc_output',
+  '.vscode',
+  'build',
+  'coverage',
+  'dist',
+  'temp',
+  'tmp',
+])
+
+/**
+ * Package discovery must not descend into installed dependencies, generated
+ * package-manager trees, or build output. Manifests in those directories are
+ * implementation details, not dependency declarations owned by the project.
+ */
+export function shouldSkipPackageDirectory(dirName: string): boolean {
+  return dirName.startsWith('.')
+    || GENERATED_DEPENDENCY_DIRECTORIES.has(dirName)
+    || GENERATED_OUTPUT_DIRECTORIES.has(dirName)
+}

--- a/test/bun-deps.test.ts
+++ b/test/bun-deps.test.ts
@@ -28,14 +28,11 @@ const mockResolveDependencyFile = mock(() => Promise.resolve({
 
 describe('Bun deps.yaml Update Tests', () => {
   let testDir: string
-  let originalCwd: string
   let config: BuddyBotConfig
 
   beforeAll(async () => {
     // Create a temporary directory for testing
     testDir = await mkdtemp(join(tmpdir(), 'buddy-test-'))
-    originalCwd = process.cwd()
-    process.chdir(testDir)
 
     // Create a basic package.json file
     await writeFile(
@@ -95,7 +92,6 @@ describe('Bun deps.yaml Update Tests', () => {
 
   afterAll(async () => {
     // Clean up
-    process.chdir(originalCwd)
     await rm(testDir, { recursive: true, force: true })
   })
 

--- a/test/file-change-validation.test.ts
+++ b/test/file-change-validation.test.ts
@@ -1,0 +1,39 @@
+import type { FileChange } from '../src/types'
+import { describe, expect, it } from 'bun:test'
+import {
+  assertUpdateTargetsExist,
+  FileChangeValidationError,
+  normalizeRepositoryPath,
+} from '../src/utils/file-changes'
+
+describe('file change validation', () => {
+  it('normalizes repository-relative paths', () => {
+    expect(normalizeRepositoryPath('./packages\\app/package.json')).toBe('packages/app/package.json')
+  })
+
+  it('rejects paths outside the repository', () => {
+    expect(() => normalizeRepositoryPath('../package.json')).toThrow(FileChangeValidationError)
+    expect(() => normalizeRepositoryPath('/tmp/package.json')).toThrow(FileChangeValidationError)
+  })
+
+  it('allows updates only when the base target exists', async () => {
+    const files: FileChange[] = [
+      { path: 'package.json', content: '{}', type: 'update' },
+      { path: 'generated.json', content: '{}', type: 'create' },
+    ]
+
+    await expect(assertUpdateTargetsExist(files, path => path === 'package.json')).resolves.toBeUndefined()
+  })
+
+  it('rejects an update that would create a missing file', async () => {
+    const files: FileChange[] = [{
+      path: './pantry/install/cache/acorn/package.json',
+      content: '{}',
+      type: 'update',
+    }]
+
+    await expect(assertUpdateTargetsExist(files, () => false)).rejects.toThrow(
+      'Refusing to create missing update target: pantry/install/cache/acorn/package.json',
+    )
+  })
+})

--- a/test/generated-dependency-directories.test.ts
+++ b/test/generated-dependency-directories.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { RegistryClient } from '../src/registry/registry-client'
+import { PackageScanner } from '../src/scanner/package-scanner'
+import { Logger } from '../src/utils/logger'
+import { shouldSkipPackageDirectory } from '../src/utils/package-paths'
+
+const generatedDirectories = [
+  'bower_components',
+  'node_modules',
+  'pantry',
+  'ts-pantry',
+  'vendor',
+]
+
+describe('generated dependency directory filtering', () => {
+  const temporaryDirectories: string[] = []
+  const logger = Logger.quiet()
+
+  afterEach(async () => {
+    await Promise.all(temporaryDirectories.splice(0).map(directory =>
+      rm(directory, { recursive: true, force: true }),
+    ))
+  })
+
+  it('classifies package-manager install trees as generated', () => {
+    for (const directory of generatedDirectories)
+      expect(shouldSkipPackageDirectory(directory)).toBe(true)
+
+    expect(shouldSkipPackageDirectory('packages')).toBe(false)
+  })
+
+  it('excludes generated manifests from both package discovery paths', async () => {
+    const projectPath = await mkdtemp(join(tmpdir(), 'buddy-generated-dependencies-'))
+    temporaryDirectories.push(projectPath)
+
+    await writePackageJson(projectPath, 'package.json', 'root')
+    await writePackageJson(projectPath, 'packages/app/package.json', 'app')
+
+    for (const directory of generatedDirectories)
+      await writePackageJson(projectPath, `${directory}/cached/package.json`, `generated-${directory}`)
+
+    const scanner = new PackageScanner(projectPath, logger)
+    const scannedPaths = (await scanner.scanProject()).map(file => file.path)
+
+    const registryClient = new RegistryClient(projectPath, logger)
+    const registryPaths = await (registryClient as any).findPackageJsonFiles()
+
+    expect(scannedPaths.filter(path => path.endsWith('package.json')).sort()).toEqual([
+      'package.json',
+      'packages/app/package.json',
+    ])
+    expect(registryPaths.sort()).toEqual([
+      'package.json',
+      'packages/app/package.json',
+    ])
+  })
+})
+
+async function writePackageJson(projectPath: string, relativePath: string, name: string): Promise<void> {
+  const filePath = join(projectPath, relativePath)
+  await mkdir(join(filePath, '..'), { recursive: true })
+  await writeFile(filePath, JSON.stringify({
+    name,
+    dependencies: {
+      acorn: '^8.0.0',
+    },
+  }))
+}

--- a/test/ignore-paths-autoclose.test.ts
+++ b/test/ignore-paths-autoclose.test.ts
@@ -13,7 +13,6 @@ describe('IgnorePaths Auto-Close Functionality', () => {
 
   beforeEach(async () => {
     testDir = await mkdtemp(join(tmpdir(), 'buddy-ignore-paths-autoclose-'))
-    process.chdir(testDir)
     logger = new Logger(false) // Quiet logger for tests
   })
 

--- a/test/noop-commit-behavior.test.ts
+++ b/test/noop-commit-behavior.test.ts
@@ -46,6 +46,30 @@ describe('No-op commit prevention', () => {
     expect(hasPush).toBeTrue()
   })
 
+  it('does not fall back to an API create when an update target is missing from base', async () => {
+    const prov = new GitHubProvider('token', 'owner', 'repo', true) as any
+    const commands: Array<{ cmd: string, args: string[] }> = []
+    let apiCalled = false
+
+    prov.runCommand = async (command: string, args: string[]) => {
+      commands.push({ cmd: command, args })
+      if (command === 'git' && args[0] === 'cat-file')
+        throw new Error('missing from base')
+      return ''
+    }
+    prov.apiRequest = async () => {
+      apiCalled = true
+      return {}
+    }
+
+    await expect(prov.commitChanges('buddy/test-branch', 'test message', filesChanged)).rejects.toThrow(
+      'Refusing to create missing update target: test-package.json',
+    )
+
+    expect(apiCalled).toBeFalse()
+    expect(commands.some(command => command.args[0] === 'add')).toBeFalse()
+  })
+
   it('skips API commit when new tree equals current tree (API fallback path)', async () => {
     const prov = new GitHubProvider('token', 'owner', 'repo', true) as any
     const apiCalls: Array<{ endpoint: string, data: any }> = []

--- a/test/pr-body-version-ranges.test.ts
+++ b/test/pr-body-version-ranges.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, it } from 'bun:test'
+import { PullRequestGenerator } from '../src/pr/pr-generator'
+import { ReleaseNotesFetcher } from '../src/services/release-notes-fetcher'
+
+describe('PR body version ranges', () => {
+  beforeAll(() => {
+    process.env.APP_ENV = 'test'
+  })
+
+  it('keeps compound npm ranges inside one table cell and URL-encodes links', async () => {
+    const generator = new PullRequestGenerator({
+      repository: {
+        provider: 'github',
+        owner: 'stacksjs',
+        name: 'stacks',
+      },
+    })
+
+    const body = await generator.generateBody({
+      name: 'Major Update - acorn',
+      title: 'chore(deps): update dependency acorn to 8.17.0',
+      body: '',
+      updateType: 'major',
+      updates: [{
+        name: 'acorn',
+        currentVersion: '^6.0.0 || ^7.0.0 || ^8.0.0',
+        newVersion: '8.17.0',
+        updateType: 'major',
+        dependencyType: 'peerDependencies',
+        file: 'package.json',
+      }],
+    })
+
+    expect(body).toContain('`^6.0.0 \\|\\| ^7.0.0 \\|\\| ^8.0.0`')
+    expect(body).toContain('%5E6.0.0%20%7C%7C%20%5E7.0.0%20%7C%7C%20%5E8.0.0')
+    expect(body).toContain('/compare/v8.0.0...v8.17.0')
+    expect(body).not.toContain('/compare/v^6.0.0 ||')
+  })
+
+  it('bounds release selection to the requested range', () => {
+    const fetcher = new ReleaseNotesFetcher() as any
+
+    expect(fetcher.isVersionBetween('8.16.0', '^6.0.0 || ^7.0.0 || ^8.0.0', '8.17.0')).toBe(true)
+    expect(fetcher.isVersionBetween('9.0.0', '^6.0.0 || ^7.0.0 || ^8.0.0', '8.17.0')).toBe(false)
+    expect(fetcher.isVersionBetween('8.0.0', '^6.0.0 || ^7.0.0 || ^8.0.0', '8.17.0')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- exclude installed and generated dependency trees such as `pantry`, `ts-pantry`, `vendor`, and `node_modules` from both package discovery paths
- reject `update` file changes when the target does not exist on the base branch
- escape compound version ranges in Markdown tables and URL-encode version path segments
- normalize compare ranges and keep release selection within the requested target

## Root cause

Buddy scanned ignored Pantry cache manifests as project-owned package files. The package lookup then selected one of those generated manifests, and the Git provider silently treated a missing `update` target as a new file. Compound peer ranges also introduced raw table delimiters and invalid compare URLs into the PR body.

## Impact

Dependency PRs can no longer create generated Pantry paths that do not exist on the base branch. PR bodies remain valid when current versions are compound semver ranges.

## Validation

- `bun test` (708 passing)
- `bun run typecheck`
- `bun run build`
- targeted Pickier lint on all changed files

The repository-wide Pickier run still reports the pre-existing `CHANGELOG.md` heading-level error plus three existing documentation warnings.
